### PR TITLE
Fix Gear SQL error when not filling out every stat

### DIFF
--- a/app/Services/Claymore/GearService.php
+++ b/app/Services/Claymore/GearService.php
@@ -323,11 +323,13 @@ class GearService extends Service
             {
                 foreach($data['stats'] as $key=>$stat)
                 {
-                    GearStat::create([
-                        'gear_id' => $id,
-                        'stat_id' => $key,
-                        'count' => $stat,
-                    ]);
+                    if($stat != null && $stat > 0) {
+                        GearStat::create([
+                            'gear_id' => $id,
+                            'stat_id' => $key,
+                            'count' => $stat,
+                        ]);
+                    }
                 }
             }
             return $this->commitReturn(true);


### PR DESCRIPTION
The solution came from [WeaponService.php](https://github.com/Ne-wt/lorekeeper/blob/3897294fb51bfe5d87aac0ae181b69195f1968d0/app/Services/Claymore/WeaponService.php#L322)'s equivalent function! The fact one worked while the other didn't is how I discovered the difference int he first place.