### PR TITLE
fix(stats): allow user stats page to be accessed on Dreamhost

### DIFF
--- a/resources/views/home/_sidebar.blade.php
+++ b/resources/views/home/_sidebar.blade.php
@@ -8,7 +8,7 @@
         <div class="sidebar-item"><a href="{{ url('inventory') }}" class="{{ set_active('inventory*') }}">Inventory</a></div>
         <div class="sidebar-item"><a href="{{ url('bank') }}" class="{{ set_active('bank*') }}">Bank</a></div>
         <div class="sidebar-item"><a href="{{ url('armoury') }}" class="{{ set_active('armoury*') }}">Armoury</a></div>
-        <div class="sidebar-item"><a href="{{ url('stats') }}" class="{{ set_active('stats*') }}">Stat Information</a></div>
+        <div class="sidebar-item"><a href="{{ url('userstats') }}" class="{{ set_active('userstats*') }}">Stat Information</a></div>
     </li>
     <li class="sidebar-section">
         <div class="sidebar-section-header">Activity</div>

--- a/resources/views/home/stats.blade.php
+++ b/resources/views/home/stats.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('home-content')
-    {!! breadcrumbs(['Stats' => 'stats']) !!}
+    {!! breadcrumbs(['Stats' => 'userstats']) !!}
 
     <h1>
         Your Stat Information

--- a/resources/views/layouts/_nav.blade.php
+++ b/resources/views/layouts/_nav.blade.php
@@ -47,7 +47,7 @@
                             <a class="dropdown-item" href="{{ url('bank') }}">
                                 Bank
                             </a>
-                            <a class="dropdown-item" href="{{ url('stats') }}">
+                            <a class="dropdown-item" href="{{ url('userstats') }}">
                                 Stat Information
                             </a>
                             <div class="dropdown-divider"></div>

--- a/resources/views/user/stats.blade.php
+++ b/resources/views/user/stats.blade.php
@@ -15,7 +15,7 @@
 
     <div class="container mb-3 text-right">
         @if (Auth::check() && Auth::user()->id == $user->id)
-            <a href="{{ url('stats') }}">
+            <a href="{{ url('userstats') }}">
                 <div class="btn btn-primary mr-0">
                     Go to Personal Stat Page
                 </div>

--- a/resources/views/widgets/_level_info.blade.php
+++ b/resources/views/widgets/_level_info.blade.php
@@ -22,7 +22,7 @@
                             <p>You have enough EXP to advance to the next level!</p>
                         </b>
                     </div>
-                    {!! Form::open(['url' => $level->user ? '/stats/level' : $level->character->url . '/stats/level']) !!}
+                    {!! Form::open(['url' => $level->user ? '/userstats/level' : $level->character->url . '/stats/level']) !!}
 
                     {!! Form::submit('Level up!', ['class' => 'btn btn-success mb-2']) !!}
 

--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -123,7 +123,7 @@ Route::group(['prefix' => 'bank', 'namespace' => 'Users'], function () {
     Route::post('transfer', 'BankController@postTransfer');
 });
 
-Route::group(['prefix' => 'stats', 'namespace' => 'Users'], function () {
+Route::group(['prefix' => 'userstats', 'namespace' => 'Users'], function () {
     Route::get('/', 'UserStatController@getIndex');
     Route::post('level', 'UserStatController@postLevel');
     Route::post('transfer', 'UserStatController@postTransfer');
@@ -181,10 +181,6 @@ Route::group(['prefix' => 'myo', 'namespace' => 'Characters'], function () {
 
     Route::post('{id}/approval', 'MyoController@postCharacterApproval');
     Route::get('{id}/approval', 'MyoController@getCharacterApproval');
-});
-
-Route::group(['prefix' => 'stats', 'namespace' => 'Users'], function () {
-    Route::get('/', 'UserStatController@getIndex');
 });
 
 /**************************************************************************************************


### PR DESCRIPTION
The `/stats` page, when accessed by users hosting their site via Dreamhost, causes a login popup to occur. This is because `/stats` on Dreamhost is a sub-directory used to serve web server analytics - if the site owner has the analytics turned on, it will completely override the `/stats` page and show web server visitor information instead. These changes makes the personal stat page for users display on `/userstats` instead, which will allow users of sites on Dreamhost to access the page without dealing with the popup.

**Changes made:**
- Changes user stats page route group prefix in members.php from 'stats' to 'userstats', as well as deleting a duplicate route group
- Updates links to the stats page to the new url in home sidebar, nav, and user stats blade
- Updates level up button url
- Updates breadcrumb on personal user stats page