### PR TITLE
fix 500 error on claims

### DIFF
--- a/resources/views/home/submission.blade.php
+++ b/resources/views/home/submission.blade.php
@@ -12,7 +12,7 @@
     @auth
         @if ($submission->user_id == Auth::user()->id && $submission->status == 'Pending')
             {!! Form::open(['url' => url()->current(), 'id' => 'submissionForm']) !!}
-            @if (!count(getLimits($submission->prompt)))
+            @if ($isClaim || !count(getLimits($submission->prompt)))
                 <div class="text-right">
                     <a href="#" class="btn btn-danger mr-2" id="cancellationButton">Cancel {{ $submission->prompt_id ? 'submission' : 'claim' }}</a>
                 </div>


### PR DESCRIPTION
when viewing their own Claim, users encounter a 500 error due to $submission->prompt being passed as null to the getLimits helper. added a check to the submission blade to get around this if $isClaim is true, as Claims do not have a prompt to pass.