### PR TITLE
fix: miscellaneous fixes to weapon/gear and their categories, levels, and stats

### DIFF
--- a/app/Http/Controllers/Admin/Stats/LevelController.php
+++ b/app/Http/Controllers/Admin/Stats/LevelController.php
@@ -17,18 +17,18 @@ class LevelController extends Controller {
      *
      * @return \Illuminate\Contracts\Support\Renderable
      */
-    public function getLevels($type = 'Character') {
+    public function getLevels(Request $request, $type = 'Character') {
         $levels = Level::ordered($type);
 
-        $page = (int) request('page', 1);
-        $perPage = 20;
+        //$page = (int) request('page', 1);
+        //$perPage = 20;
 
         return view('admin.levels.levels', [
             'type'   => $type,
-            'levels' => $levels->forPage($page, $perPage),
+            'levels' => $levels->paginate(20)->appends($request->query()),
         ]);
     }
-
+    
     /**
      * Shows the create level page.
      *

--- a/app/Http/Controllers/Admin/Stats/LevelController.php
+++ b/app/Http/Controllers/Admin/Stats/LevelController.php
@@ -20,15 +20,15 @@ class LevelController extends Controller {
     public function getLevels(Request $request, $type = 'Character') {
         $levels = Level::ordered($type);
 
-        //$page = (int) request('page', 1);
-        //$perPage = 20;
+        // $page = (int) request('page', 1);
+        // $perPage = 20;
 
         return view('admin.levels.levels', [
             'type'   => $type,
             'levels' => $levels->paginate(20)->appends($request->query()),
         ]);
     }
-    
+
     /**
      * Shows the create level page.
      *

--- a/app/Models/Claymore/Gear.php
+++ b/app/Models/Claymore/Gear.php
@@ -235,7 +235,7 @@ class Gear extends Model {
      * @return string
      */
     public function getUrlAttribute() {
-        return url('world/gear?name='.$this->name);
+        return url('world/gears?name='.$this->name);
     }
 
     /**
@@ -244,7 +244,7 @@ class Gear extends Model {
      * @return string
      */
     public function getIdUrlAttribute() {
-        return url('world/gear/'.$this->id);
+        return url('world/gears/'.$this->id);
     }
 
     /**

--- a/app/Services/Stat/StatService.php
+++ b/app/Services/Stat/StatService.php
@@ -66,7 +66,7 @@ class StatService extends Service {
             if (!isset($data['name'])) {
                 throw new \Exception('Please provide a name for the stat.');
             }
-            if (!isset($data['base'])) {
+            if ($stat->id !== config('lorekeeper.claymores_and_companions.stat_points.general_id') && !isset($data['base'])) {
                 throw new \Exception('Please set a base stat value.');
             }
             if (isset($data['colour'])) {

--- a/database/migrations/2026_03_07_225854_fix_gear_descriptions.php
+++ b/database/migrations/2026_03_07_225854_fix_gear_descriptions.php
@@ -4,13 +4,11 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */
-    public function up(): void
-    {
+    public function up(): void {
         Schema::table('gears', function (Blueprint $table) {
             $table->text('description')->change();
         });
@@ -19,8 +17,7 @@ return new class extends Migration
     /**
      * Reverse the migrations.
      */
-    public function down(): void
-    {
+    public function down(): void {
         Schema::table('gears', function (Blueprint $table) {
             $table->string('description')->change();
         });

--- a/database/migrations/2026_03_07_225854_fix_gear_descriptions.php
+++ b/database/migrations/2026_03_07_225854_fix_gear_descriptions.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('gears', function (Blueprint $table) {
+            $table->text('description')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('gears', function (Blueprint $table) {
+            $table->string('description')->change();
+        });
+    }
+};

--- a/resources/views/admin/claymores/gear/create_edit_gear.blade.php
+++ b/resources/views/admin/claymores/gear/create_edit_gear.blade.php
@@ -126,6 +126,10 @@
                     'description' => $gear->description,
                     'searchUrl' => $gear->searchUrl,
                     'visible' => $gear->is_visible,
+                    'edit' => [
+                        'title' => 'Edit Gear',
+                        'object' => $gear,
+                    ],
                 ])
             </div>
         </div>

--- a/resources/views/admin/claymores/gear/create_edit_gear_category.blade.php
+++ b/resources/views/admin/claymores/gear/create_edit_gear_category.blade.php
@@ -66,11 +66,13 @@
         <h3>Preview</h3>
         <div class="card mb-3">
             <div class="card-body">
-                @include('world._claymore_entry', [
-                    'item' => null,
+                @include('world._entry', [
+                    'edit' => ['object' => $category, 'title' => 'Gear Category'],
+                    'item' => $category,
                     'imageUrl' => $category->categoryImageUrl,
                     'name' => $category->displayName,
-                    'description' => $category->description,
+                    'description' => $category->parsed_description,
+                    'searchUrl' => $category->searchUrl,
                     'category' => $category,
                     'visible' => $category->is_visible,
                 ])

--- a/resources/views/admin/claymores/weapon/create_edit_weapon.blade.php
+++ b/resources/views/admin/claymores/weapon/create_edit_weapon.blade.php
@@ -126,6 +126,10 @@
                     'description' => $weapon->description,
                     'searchUrl' => $weapon->searchUrl,
                     'visible' => $weapon->is_visible,
+                    'edit' => [
+                        'title' => 'Edit Weapon',
+                        'object' => $weapon,
+                    ],
                 ])
             </div>
         </div>

--- a/resources/views/admin/claymores/weapon/create_edit_weapon_category.blade.php
+++ b/resources/views/admin/claymores/weapon/create_edit_weapon_category.blade.php
@@ -66,11 +66,13 @@
         <h3>Preview</h3>
         <div class="card mb-3">
             <div class="card-body">
-                @include('world._claymore_entry', [
-                    'item' => null,
+                @include('world._entry', [
+                    'edit' => ['object' => $category, 'title' => 'Weapon Category'],
+                    'item' => $category,
                     'imageUrl' => $category->categoryImageUrl,
                     'name' => $category->displayName,
-                    'description' => $category->description,
+                    'description' => $category->parsed_description,
+                    'searchUrl' => $category->searchUrl,
                     'category' => $category,
                     'visible' => $category->is_visible,
                 ])

--- a/resources/views/admin/elements/create_edit_element.blade.php
+++ b/resources/views/admin/elements/create_edit_element.blade.php
@@ -114,6 +114,7 @@
 
 @section('scripts')
     @parent
+    @include('js._tinymce_wysiwyg')
     <script>
         $(document).ready(function() {
             $('.selectize').selectize();

--- a/resources/views/admin/levels/levels.blade.php
+++ b/resources/views/admin/levels/levels.blade.php
@@ -31,6 +31,7 @@
         {!! Form::close() !!}
     </div>
 
+    {!! $levels->render() !!}
     @if (!count($levels))
         <p>No levels found.</p>
     @else
@@ -68,4 +69,6 @@
             </tbody>
         </table>
     @endif
+    {!! $levels->render() !!}
+    
 @endsection

--- a/resources/views/admin/levels/levels.blade.php
+++ b/resources/views/admin/levels/levels.blade.php
@@ -70,5 +70,5 @@
         </table>
     @endif
     {!! $levels->render() !!}
-    
+
 @endsection

--- a/resources/views/admin/skills/create_edit_skill.blade.php
+++ b/resources/views/admin/skills/create_edit_skill.blade.php
@@ -137,6 +137,7 @@
 
 @section('scripts')
     @parent
+    @include('js._tinymce_wysiwyg')
     <script>
         $(document).ready(function() {
             $('.selectize').selectize();

--- a/resources/views/admin/skills/create_edit_skill_category.blade.php
+++ b/resources/views/admin/skills/create_edit_skill_category.blade.php
@@ -66,6 +66,7 @@
 
 @section('scripts')
     @parent
+    @include('js._tinymce_wysiwyg')
     <script>
         $(document).ready(function() {
             $('.delete-category-button').on('click', function(e) {

--- a/resources/views/admin/stats/create_edit_stat.blade.php
+++ b/resources/views/admin/stats/create_edit_stat.blade.php
@@ -74,7 +74,12 @@
         </div>
         <div class="col-md form-group">
             {!! Form::label('Colour') !!} {!! add_help('This is the colour that will be used to display the stat on the character page. Set it to white to disable.') !!}
-            {!! Form::color('colour', $stat->colour, ['class' => 'form-control']) !!}
+            <div class="input-group cp">
+                {!! Form::text('colour', $stat->colour, ['class' => 'form-control']) !!}
+                <span class="input-group-append">
+                    <span class="input-group-text colorpicker-input-addon"><i></i></span>
+                </span>
+            </div>
         </div>
     </div>
 

--- a/resources/views/admin/statuses/create_edit_status.blade.php
+++ b/resources/views/admin/statuses/create_edit_status.blade.php
@@ -98,6 +98,7 @@
 
 @section('scripts')
     @parent
+    @include('js._tinymce_wysiwyg')
     <script>
         $(document).ready(function() {
             $('#add-severity').on('click', function(e) {

--- a/resources/views/world/_sidebar.blade.php
+++ b/resources/views/world/_sidebar.blade.php
@@ -41,7 +41,7 @@
                 <div class="sidebar-item"><a href="{{ url('world/levels/character') }}" class="{{ set_active('world/levels/character*') }}">Character Levels</a></div>
             @endif
             @if (config('lorekeeper.claymores_and_companions.visibility_settings.character_stats'))
-                <div class="sidebar-item"><a href="{{ url('world/character-stats') }}" class="{{ set_active('world/character-stats*') }}">Character Stats</a></div>
+                <div class="sidebar-item"><a href="{{ url('world/stats') }}" class="{{ set_active('world/stats*') }}">Character Stats</a></div>
             @endif
         </li>
     @endif
@@ -58,7 +58,7 @@
             @endif
             @if (config('lorekeeper.claymores_and_companions.visibility_settings.gear'))
                 <div class="sidebar-item"><a href="{{ url('world/gear-categories') }}" class="{{ set_active('world/gear-categories*') }}">Gear Categories</a></div>
-                <div class="sidebar-item"><a href="{{ url('world/gear') }}" class="{{ set_active('world/gear*') }}">All Gear</a></div>
+                <div class="sidebar-item"><a href="{{ url('world/gears') }}" class="{{ set_active('world/gears*') }}">All Gear</a></div>
             @endif
         </li>
     @endif

--- a/resources/views/world/gear_categories.blade.php
+++ b/resources/views/world/gear_categories.blade.php
@@ -23,9 +23,9 @@
     @foreach ($categories as $category)
         <div class="card mb-3">
             <div class="card-body">
-                @include('world._claymore_entry', [
+                @include('world._entry', [
                     'edit' => ['object' => $category, 'title' => 'Gear Category'],
-                    'item' => null,
+                    'item' => $category,
                     'imageUrl' => $category->categoryImageUrl,
                     'name' => $category->displayName,
                     'description' => $category->parsed_description,

--- a/resources/views/world/weapon_categories.blade.php
+++ b/resources/views/world/weapon_categories.blade.php
@@ -23,12 +23,13 @@
     @foreach ($categories as $category)
         <div class="card mb-3">
             <div class="card-body">
-                @include('world._claymore_entry', [
+                @include('world._entry', [
                     'edit' => ['object' => $category, 'title' => 'Weapon Category'],
-                    'item' => null,
+                    'item' => $category,
                     'imageUrl' => $category->categoryImageUrl,
                     'name' => $category->displayName,
                     'description' => $category->parsed_description,
+                    'searchUrl' => $category->searchUrl,
                     'category' => $category,
                     'visible' => $category->is_visible,
                 ])

--- a/routes/lorekeeper/browse.php
+++ b/routes/lorekeeper/browse.php
@@ -153,8 +153,8 @@ Route::group(['prefix' => 'world'], function () {
     Route::get('weapons', 'WorldController@getWeapons');
     Route::get('weapons/{id}', 'WorldController@getWeapon');
     Route::get('gear-categories', 'WorldController@getGearCategories');
-    Route::get('gear', 'WorldController@getGears');
-    Route::get('gear/{id}', 'WorldController@getGear');
+    Route::get('gears', 'WorldController@getGears');
+    Route::get('gears/{id}', 'WorldController@getGear');
     Route::get('character-classes', 'WorldController@getCharacterClasses');
     Route::get('skill-categories', 'WorldController@getSkillCategories');
     Route::get('skills', 'WorldController@getSkills');


### PR DESCRIPTION
Just a whole host of fixes I found (sorry it's all lumped into one PR/commit, I copied these over from a site I was working on, lol):
  
 - Gear description column being a string and not text
 - Use `world._entry` and not `claymore._entry` for gear and weapon categories to prevent 500 errors on create/edit pages and the encyclopedia
 - Fixed missing 'edit' value from various `claymore._entry` includes
 - Allow general stat to be updated without getting blocked by the base stat value check
 - Use the JS color picker for stat color
 - Proper pagination on the admin LevelController getLevels() function
 - Incorrect URL for stats on the encyclopedia sidebar
 - Incorrect highlighting for gear on the encyclopedia sidebar (fixed by making sure the beginning of the URL isn't shared, much like skills and weapons)
 - Added missing `@include('js._tinymce_wysiwyg')` for status, elements, skills, and skill categories
 
 Does include a migration to fix the gear description column, so `php artisan migrate` will need to be run.
 
 Thanks for your time!