### PR TITLE
fix: drop cap using wrong variable names

### DIFF
--- a/app/Services/PetDropService.php
+++ b/app/Services/PetDropService.php
@@ -54,7 +54,7 @@ class PetDropService extends Service {
                 'frequency'  => $data['drop_frequency'],
                 'interval'   => $data['drop_interval'],
                 'is_active'  => $data['is_active'] ?? 0,
-                'cap'        => $data['drop_cap'] ?? 0,
+                'cap'        => $data['cap'] ?? 0,
                 'name'       => $data['drop_name'] ?? 'drop',
                 'override'   => $data['override'] ?? 0,
             ]);

--- a/resources/views/admin/pets/create_edit_drop.blade.php
+++ b/resources/views/admin/pets/create_edit_drop.blade.php
@@ -69,7 +69,7 @@
     </div>
     <div class="form-group">
         {!! Form::label('cap', 'Drop Cap (Optional)', ['class' => 'form-label ml-3']) !!} {!! add_help('How many batches of drops are allowed to accumulate. Either set to 0 or unset to allow unlimited accumulation.') !!}
-        {!! Form::number('cap', $drop->id ?? null, ['class' => 'form-control mr-2', 'placeholder' => 'Drop Cap']) !!}
+        {!! Form::number('cap', $drop->cap ?? null, ['class' => 'form-control mr-2', 'placeholder' => 'Drop Cap']) !!}
     </div>
     <div class="form-group">
         {!! Form::checkbox('is_active', 1, $drop->id ? $drop->isActive : 1, ['class' => 'form-check-input', 'data-toggle' => 'toggle']) !!}


### PR DESCRIPTION
Exactly what it says, just fixes a long-standing bug with drop blade displaying cap as `$drop->id` and the create function trying to access `$data['drop_cap']`.