### PR TITLE
fix: bugs with changing pet variants

### DIFF
--- a/app/Console/Commands/FixPetDropIds.php
+++ b/app/Console/Commands/FixPetDropIds.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Pet\PetDrop;
+use Illuminate\Console\Command;
+
+class FixPetDropIds extends Command {
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fix-pet-drop-ids';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fixes inconsistent pet drop data IDs';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle() {
+        $drops = PetDrop::all();
+        foreach ($drops as $drop) {
+            if ($drop->user_pet !== null) {
+                if (isset($drop->user_pet->pet->dropData) && ($drop->drop_id !== $drop->user_pet->pet->dropData->id)) {
+                    $drop->update([
+                        'drop_id' => $drop->user_pet->pet->dropData->id,
+                    ]);
+                    $this->line("Corrected pet ID #".$drop->user_pet->id."\n");
+                } elseif(!isset($drop->user_pet->pet->dropData)) {
+                    // the pet has no drop data and the PetDrop can be deleted
+                    $drop->delete();
+                    $this->line("Deleted drop data for pet #".$drop->user_pet->id." that has no drops\n");
+                }
+            } else {
+                // the pet is deleted and the PetDrop is no longer needed
+                $drop->delete();
+                $this->line("Deleted drop data for deleted pet #".$drop->user_pet->id."\n");
+            }
+        }
+    }
+}

--- a/app/Console/Commands/FixPetDropIds.php
+++ b/app/Console/Commands/FixPetDropIds.php
@@ -32,15 +32,15 @@ class FixPetDropIds extends Command {
                         'drop_id' => $drop->user_pet->pet->dropData->id,
                     ]);
                     $this->line("Corrected pet ID #".$drop->user_pet->id."\n");
-                } elseif(!isset($drop->user_pet->pet->dropData)) {
+                } elseif (!isset($drop->user_pet->pet->dropData)) {
                     // the pet has no drop data and the PetDrop can be deleted
+                    $this->line('Deleted drop data for pet #'.$drop->user_pet_id." that has no drops\n");
                     $drop->delete();
-                    $this->line("Deleted drop data for pet #".$drop->user_pet->id." that has no drops\n");
                 }
             } else {
                 // the pet is deleted and the PetDrop is no longer needed
+                $this->line('Deleted drop data for deleted pet #'.$drop->user_pet_id."\n");
                 $drop->delete();
-                $this->line("Deleted drop data for deleted pet #".$drop->user_pet->id."\n");
             }
         }
     }

--- a/app/Services/PetManager.php
+++ b/app/Services/PetManager.php
@@ -507,6 +507,7 @@ class PetManager extends Service {
                 if(isset($newPet->dropData)) {
                     if($pet->drops->drop_id !== $newPet->dropData->id) {
                         $pet->drops->drop_id = $newPet->dropData->id;
+                        $pet->drops->save();
                     }
                 } else {
                     //the new variant does not have drops, so we discard the old drops row

--- a/app/Services/PetManager.php
+++ b/app/Services/PetManager.php
@@ -459,13 +459,19 @@ class PetManager extends Service {
         DB::beginTransaction();
 
         try {
+            // find parent if id is default
+            if ($id == 0) {
+                $pet_type = Pet::find($pet->pet_id);
+                $id = $pet_type->parent == null ? null : $pet_type->parent->id;
+            }
+
+            if ($id == null) {
+                throw new \Exception('Pet is already the default variant.');
+            }
+
             if (!$isStaff || !Auth::user()->isStaff) {
                 if (!$stack_id) {
                     throw new \Exception('No item selected.');
-                }
-
-                if ($id == 0) {
-                    $id = 'default';
                 }
 
                 // check if user has item
@@ -489,11 +495,24 @@ class PetManager extends Service {
                     throw new \Exception('Could not debit item.');
                 }
             } else {
-                $this->logAdminAction($pet->user, 'Pet Variant Changed', 'Changed pet id #'.$pet->id.'/'.$pet->pet->name.' to variant '.Pet::find($id)->name);
+                $this->logAdminAction($pet->user, 'Pet Variant Changed', 'Changed pet to '.$pet->pet->name.' variant');
             }
 
-            $pet->pet_id = $id == 'default' ? null : $id;
+            $pet->pet_id = $id;
             $pet->save();
+
+            // update pet drop, if relevant
+            if (isset($pet->drops)) { 
+                $newPet = Pet::find($id);
+                if(isset($newPet->dropData)) {
+                    if($pet->drops->drop_id !== $newPet->dropData->id) {
+                        $pet->drops->drop_id = $newPet->dropData->id;
+                    }
+                } else {
+                    //the new variant does not have drops, so we discard the old drops row
+                    $pet->drops()->delete();
+                }
+            }
 
             return $this->commitReturn(true);
         } catch (\Exception $e) {
@@ -738,6 +757,7 @@ class PetManager extends Service {
         DB::beginTransaction();
 
         try {
+            $stack->drops()->delete();
             $stack->delete();
 
             if ($type && !$this->createLog($user ? $user->id : null, null, $stack->id, $type, $data['data'], $stack->pet_id, 1)) {

--- a/app/Services/PetManager.php
+++ b/app/Services/PetManager.php
@@ -495,7 +495,7 @@ class PetManager extends Service {
                     throw new \Exception('Could not debit item.');
                 }
             } else {
-                $this->logAdminAction($pet->user, 'Pet Variant Changed', 'Changed pet to '.$pet->pet->name.' variant');
+                $this->logAdminAction($pet->user, 'Pet Variant Changed', 'Changed pet id #'.$pet->id.'/'.$pet->pet->name.' to variant '.Pet::find($id)->name);
             }
 
             $pet->pet_id = $id;

--- a/resources/views/home/_pet_form.blade.php
+++ b/resources/views/home/_pet_form.blade.php
@@ -79,9 +79,9 @@
     <li class="list-group-item">
         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#userVariantForm">Change Pet Variant</a>
         {!! Form::open(['url' => 'pets/variant/' . $pet->id, 'id' => 'userVariantForm', 'class' => 'collapse']) !!}
-        @if(isset($pet->drops) && $pet->drops->drops_available > 0)
+        @if (isset($pet->drops) && $pet->drops->drops_available > 0)
             <div class="alert alert-danger">
-                This pet currently has available drops. Changing its variant may alter or remove their currently available drops. 
+                This pet currently has available drops. Changing its variant may alter or remove their currently available drops.
                 <br>
                 <b>Please collect your drops before changing this pet's variant.</b>
             </div>
@@ -114,7 +114,7 @@
         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#variantForm">[ADMIN] Change Pet Variant</a>
         {!! Form::open(['url' => 'pets/variant/' . $pet->id, 'id' => 'variantForm', 'class' => 'collapse']) !!}
         {!! Form::hidden('is_staff', 1) !!}
-        @if(isset($pet->drops) && $pet->drops->drops_available > 0)
+        @if (isset($pet->drops) && $pet->drops->drops_available > 0)
             <div class="alert alert-danger">
                 This pet currently has available drops. Changing its variant may alter or remove their currently available drops.
                 <br>

--- a/resources/views/home/_pet_form.blade.php
+++ b/resources/views/home/_pet_form.blade.php
@@ -79,10 +79,17 @@
     <li class="list-group-item">
         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#userVariantForm">Change Pet Variant</a>
         {!! Form::open(['url' => 'pets/variant/' . $pet->id, 'id' => 'userVariantForm', 'class' => 'collapse']) !!}
+        @if(isset($pet->drops) && $pet->drops->drops_available > 0)
+            <div class="alert alert-danger">
+                This pet currently has available drops. Changing its variant may alter or remove their currently available drops. 
+                <br>
+                <b>Please collect your drops before changing this pet's variant.</b>
+            </div>
+        @endif
         <p>
             This will use a splice item!
             @if ($pet->pet->isVariant)
-                <br>Current Variant: {{ $pet->pet->name }}
+                <br><b>Current Variant:</b> {{ $pet->pet->name }}
             @endif
         </p>
         <div class="form-group">
@@ -90,7 +97,7 @@
         </div>
         <div class="form-group">
             @php
-                $variants = ['0' => 'Default'] + ($pet->pet->isVariant ? $pet->pet->parent->variants()->pluck('name', 'id')->toArray() : $pet->pet->variants()->pluck('name', 'id')->toArray());
+                $variants = [0 => 'Default'] + ($pet->pet->isVariant ? $pet->pet->parent->variants()->pluck('name', 'id')->toArray() : $pet->pet->variants()->pluck('name', 'id')->toArray());
             @endphp
             {!! Form::select('variant_id', $variants, $pet->variant_id, ['class' => 'form-control']) !!}
         </div>
@@ -107,9 +114,16 @@
         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#variantForm">[ADMIN] Change Pet Variant</a>
         {!! Form::open(['url' => 'pets/variant/' . $pet->id, 'id' => 'variantForm', 'class' => 'collapse']) !!}
         {!! Form::hidden('is_staff', 1) !!}
+        @if(isset($pet->drops) && $pet->drops->drops_available > 0)
+            <div class="alert alert-danger">
+                This pet currently has available drops. Changing its variant may alter or remove their currently available drops.
+                <br>
+                <b>Inform the user to collect their drops before changing this pet's variant.</b>
+            </div>
+        @endif
         <div class="form-group">
             @php
-                $variants = ['0' => 'Default'] + ($pet->pet->isVariant ? $pet->pet->parent->variants()->pluck('name', 'id')->toArray() : $pet->pet->variants()->pluck('name', 'id')->toArray());
+                $variants = [0 => 'Default'] + ($pet->pet->isVariant ? $pet->pet->parent->variants()->pluck('name', 'id')->toArray() : $pet->pet->variants()->pluck('name', 'id')->toArray());
             @endphp
             {!! Form::select('variant_id', $variants, $pet->variant_id, ['class' => 'form-control mt-2']) !!}
         </div>
@@ -126,7 +140,7 @@
         {!! Form::hidden('is_staff', 1) !!}
         <div class="form-group">
             @php
-                $evolutions = ['0' => 'Default'] + $pet->pet->evolutions()->pluck('evolution_name', 'id')->toArray();
+                $evolutions = [0 => 'Default'] + $pet->pet->evolutions()->pluck('evolution_name', 'id')->toArray();
             @endphp
             {!! Form::select('evolution_id', $evolutions, $pet->evolution_id, ['class' => 'form-control mt-2']) !!}
         </div>

--- a/resources/views/home/_pet_stack.blade.php
+++ b/resources/views/home/_pet_stack.blade.php
@@ -110,9 +110,9 @@
                     <li class="list-group-item">
                         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#userVariantForm">Change Pet Variant</a>
                         {!! Form::open(['url' => 'pets/variant/' . $stack->id, 'id' => 'userVariantForm', 'class' => 'collapse']) !!}
-                        @if(isset($stack->drops) && $stack->drops->drops_available > 0)
+                        @if (isset($stack->drops) && $stack->drops->drops_available > 0)
                             <div class="alert alert-danger">
-                                This pet currently has available drops. Changing its variant may alter or remove their currently available drops. 
+                                This pet currently has available drops. Changing its variant may alter or remove their currently available drops.
                                 <br>
                                 <b>Please collect your drops before changing this pet's variant.</b>
                             </div>
@@ -145,7 +145,7 @@
                         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#variantForm">[ADMIN] Change Pet Variant</a>
                         {!! Form::open(['url' => 'pets/variant/' . $stack->id, 'id' => 'variantForm', 'class' => 'collapse']) !!}
                         {!! Form::hidden('is_staff', 1) !!}
-                        @if(isset($stack->drops) && $stack->drops->drops_available > 0)
+                        @if (isset($stack->drops) && $stack->drops->drops_available > 0)
                             <div class="alert alert-danger">
                                 This pet currently has available drops. Changing its variant may alter or remove their currently available drops.
                                 <br>

--- a/resources/views/home/_pet_stack.blade.php
+++ b/resources/views/home/_pet_stack.blade.php
@@ -110,10 +110,17 @@
                     <li class="list-group-item">
                         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#userVariantForm">Change Pet Variant</a>
                         {!! Form::open(['url' => 'pets/variant/' . $stack->id, 'id' => 'userVariantForm', 'class' => 'collapse']) !!}
+                        @if(isset($stack->drops) && $stack->drops->drops_available > 0)
+                            <div class="alert alert-danger">
+                                This pet currently has available drops. Changing its variant may alter or remove their currently available drops. 
+                                <br>
+                                <b>Please collect your drops before changing this pet's variant.</b>
+                            </div>
+                        @endif
                         <p>
                             This will use a splice item!
                             @if ($stack->pet->isVariant)
-                                <br><b>Current variant:</b> {{ $stack->pet->name }}
+                                <br><b>Current Variant:</b> {{ $stack->pet->name }}
                             @endif
                         </p>
                         <div class="form-group">
@@ -121,7 +128,7 @@
                         </div>
                         <div class="form-group">
                             @php
-                                $variants = ['0' => 'Default'] + ($stack->pet->isVariant ? $stack->pet->parent->variants()->pluck('name', 'id')->toArray() : $stack->pet->variants()->pluck('name', 'id')->toArray());
+                                $variants = [0 => 'Default'] + ($stack->pet->isVariant ? $stack->pet->parent->variants()->pluck('name', 'id')->toArray() : $stack->pet->variants()->pluck('name', 'id')->toArray());
                             @endphp
                             {!! Form::select('variant_id', $variants, $stack->pet->parent_id, ['class' => 'form-control']) !!}
                         </div>
@@ -138,14 +145,21 @@
                         <a class="card-title h5 collapse-title" data-toggle="collapse" href="#variantForm">[ADMIN] Change Pet Variant</a>
                         {!! Form::open(['url' => 'pets/variant/' . $stack->id, 'id' => 'variantForm', 'class' => 'collapse']) !!}
                         {!! Form::hidden('is_staff', 1) !!}
+                        @if(isset($stack->drops) && $stack->drops->drops_available > 0)
+                            <div class="alert alert-danger">
+                                This pet currently has available drops. Changing its variant may alter or remove their currently available drops.
+                                <br>
+                                <b>Inform the user to collect their drops before changing this pet's variant.</b>
+                            </div>
+                        @endif
                         <p>
                             @if ($stack->variant_id)
-                                <br><b>Current variant:</b> {{ $stack->variant->name }}
+                                <br><b>Current Variant:</b> {{ $stack->variant->name }}
                             @endif
                         </p>
                         <div class="form-group">
                             @php
-                                $variants = ['0' => 'Default'] + ($stack->pet->isVariant ? $stack->pet->parent->variants()->pluck('name', 'id')->toArray() : $stack->pet->variants()->pluck('name', 'id')->toArray());
+                                $variants = [0 => 'Default'] + ($stack->pet->isVariant ? $stack->pet->parent->variants()->pluck('name', 'id')->toArray() : $stack->pet->variants()->pluck('name', 'id')->toArray());
                             @endphp
                             {!! Form::select('variant_id', $variants, $stack->pet->isVariant ? $stack->pet_id : 0, ['class' => 'form-control mt-2']) !!}
                         </div>
@@ -161,12 +175,12 @@
                         {!! Form::hidden('is_staff', 1) !!}
                         <p>
                             @if ($stack->evolution_id)
-                                <br><b>Current evolution:</b> {{ $stack->evolution->evolution_name }} (Stage {{ $stack->evolution->evolution_stage }})
+                                <br><b>Current Evolution:</b> {{ $stack->evolution->evolution_name }} (Stage {{ $stack->evolution->evolution_stage }})
                             @endif
                         </p>
                         <div class="form-group">
                             @php
-                                $evolutions = ['0' => 'Default'] + $stack->pet->evolutions()->pluck('evolution_name', 'id')->toArray();
+                                $evolutions = [0 => 'Default'] + $stack->pet->evolutions()->pluck('evolution_name', 'id')->toArray();
                             @endphp
                             {!! Form::select('evolution_id', $evolutions, $stack->evolution_id, ['class' => 'form-control mt-2']) !!}
                         </div>


### PR DESCRIPTION
Fixes a few bugs with changing pet variants (and adds a little bit of consistency polish while I was already there).

When changing a pet's variant, the `drop_id` on its related `PetDrop` falls out of sync. This can cause a variety of rather insidious and vague errors (usually something to do with a null value when looking for `drops_available`), especially when trying to mass collect drops. This fix ensures it stays in sync with its new `pet_id`.

I have included a console command `php artisan fix-pet-drop-ids` which will fix existing inconsistent PetDrops. I also included fixes to the `debitStack` and `editVariant` functions that will prevent the creation of orphaned rows in the `pet_drops` table (the command will also delete any existing orphaned rows). It's been thoroughly tested on both my local and two separate live sites, so I'm pretty sure it doesn't accidentally explode anything critical.

This PR also includes a fix for when trying to set a pet back to its "default", since it wasn't yet updated for the pet parent_id change.

A warning is now also displayed to both users and staff when you're about to change the variant on a pet that has pending drops to collect:

<img width="2323" height="814" alt="image" src="https://github.com/user-attachments/assets/7fb47824-7445-45a8-b482-2c17cbda5f81" />

<img width="2340" height="541" alt="image" src="https://github.com/user-attachments/assets/f6a9fc5e-891a-4ee9-b242-7b0d9e952e0b" />

Let me know if you want me to just disable users from being able to change variants entirely when there's pending drops, might make it a little more oh-no-I-didn't-read-regret-proof. :P

Thanks again!