### PR TITLE
fix: hardcoded experience ID, broken links, other housekeeping

### DIFF
--- a/app/Console/Commands/ConvertExperiencePoints.php
+++ b/app/Console/Commands/ConvertExperiencePoints.php
@@ -73,7 +73,7 @@ class ConvertExperiencePoints extends Command {
         $this->info("Converting experience points for {$characterCount} characters...");
         $bar = $this->output->createProgressBar($characterCount);
         $bar->start();
-        CharacterLevel::chunk(100, function ($characterLevels) use ($bar) {
+        CharacterLevel::chunk(100, function ($characterLevels) use ($bar, $experience) {
             foreach ($characterLevels as $characterLevel) {
                 CharacterExperience::create([
                     'character_id'  => $characterLevel->character_id,

--- a/app/Console/Commands/ConvertExperiencePoints.php
+++ b/app/Console/Commands/ConvertExperiencePoints.php
@@ -77,7 +77,7 @@ class ConvertExperiencePoints extends Command {
             foreach ($characterLevels as $characterLevel) {
                 CharacterExperience::create([
                     'character_id'  => $characterLevel->character_id,
-                    'experience_id' => 1,
+                    'experience_id' => $experience->id,
                     'quantity'      => $characterLevel->current_exp,
                 ]);
                 $bar->advance();

--- a/app/Console/Commands/ConvertExperiencePoints.php
+++ b/app/Console/Commands/ConvertExperiencePoints.php
@@ -38,7 +38,7 @@ class ConvertExperiencePoints extends Command {
         // run migration to create experience points table
         $this->call('migrate');
 
-        if(Experience::first() == null) {
+        if (Experience::first() == null) {
             $experience = Experience::create([
                 'name'        => 'Level Experience',
                 'has_image'   => false,
@@ -73,7 +73,7 @@ class ConvertExperiencePoints extends Command {
         $this->info("Converting experience points for {$characterCount} characters...");
         $bar = $this->output->createProgressBar($characterCount);
         $bar->start();
-        CharacterLevel::chunk(100, function ($characterLevels) use ($bar, $experience) {
+        CharacterLevel::chunk(100, function ($characterLevels) use ($bar) {
             foreach ($characterLevels as $characterLevel) {
                 CharacterExperience::create([
                     'character_id'  => $characterLevel->character_id,

--- a/app/Console/Commands/ConvertExperiencePoints.php
+++ b/app/Console/Commands/ConvertExperiencePoints.php
@@ -38,12 +38,16 @@ class ConvertExperiencePoints extends Command {
         // run migration to create experience points table
         $this->call('migrate');
 
-        Experience::create([
-            'name'        => 'Level Experience',
-            'has_image'   => false,
-            'description' => 'Experience points are earned by characters and users through various actions. They can be used to level up.',
-            'is_visible'  => false,
-        ]);
+        if(Experience::first() == null) {
+            $experience = Experience::create([
+                'name'        => 'Level Experience',
+                'has_image'   => false,
+                'description' => 'Experience points are earned by characters and users through various actions. They can be used to level up.',
+                'is_visible'  => false,
+            ]);
+        } else {
+            $experience = Experience::first();
+        }
 
         // Convert user experience points
         // chunk the updates to avoid memory issues
@@ -51,11 +55,11 @@ class ConvertExperiencePoints extends Command {
         $this->info("Converting experience points for {$userCount} users...");
         $bar = $this->output->createProgressBar($userCount);
         $bar->start();
-        UserLevel::chunk(100, function ($userLevels) use ($bar) {
+        UserLevel::chunk(100, function ($userLevels) use ($bar, $experience) {
             foreach ($userLevels as $userLevel) {
                 UserExperience::create([
                     'user_id'       => $userLevel->user_id,
-                    'experience_id' => 1,
+                    'experience_id' => $experience->id,
                     'quantity'      => $userLevel->current_exp,
                 ]);
                 $bar->advance();
@@ -69,7 +73,7 @@ class ConvertExperiencePoints extends Command {
         $this->info("Converting experience points for {$characterCount} characters...");
         $bar = $this->output->createProgressBar($characterCount);
         $bar->start();
-        CharacterLevel::chunk(100, function ($characterLevels) use ($bar) {
+        CharacterLevel::chunk(100, function ($characterLevels) use ($bar, $experience) {
             foreach ($characterLevels as $characterLevel) {
                 CharacterExperience::create([
                     'character_id'  => $characterLevel->character_id,

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -105,7 +105,7 @@ class SubmissionController extends Controller {
             'classes'             => CharacterClass::orderBy('name')->pluck('name', 'id'),
             'points'              => Stat::orderBy('name')->pluck('name', 'id')->toArray(),
             'experiences'         => Experience::orderBy('name')->pluck('name', 'id')->toArray(),
-            'skills'           => Skill::pluck('name', 'id')->toArray(),
+            'skills'              => Skill::pluck('name', 'id')->toArray(),
         ] : []));
     }
 
@@ -170,7 +170,7 @@ class SubmissionController extends Controller {
             'classes'             => CharacterClass::orderBy('name')->pluck('name', 'id'),
             'points'              => Stat::orderBy('name')->pluck('name', 'id')->toArray(),
             'experiences'         => Experience::orderBy('name')->pluck('name', 'id')->toArray(),
-            'skills'           => Skill::pluck('name', 'id')->toArray(),
+            'skills'              => Skill::pluck('name', 'id')->toArray(),
         ] : []));
     }
 

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -92,7 +92,6 @@ class SubmissionController extends Controller {
             'page'             => 'submission',
             'expanded_rewards' => config('lorekeeper.extensions.character_reward_expansion.expanded'),
             'characters'       => Character::visible(Auth::user() ?? null)->myo(0)->orderBy('slug', 'DESC')->get()->pluck('fullName', 'slug')->toArray(),
-            'skills'           => Skill::pluck('name', 'id')->toArray(),
         ] + ($submission->status == 'Pending' ? [
             'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
             'items'               => Item::orderBy('name')->pluck('name', 'id'),
@@ -106,6 +105,7 @@ class SubmissionController extends Controller {
             'classes'             => CharacterClass::orderBy('name')->pluck('name', 'id'),
             'points'              => Stat::orderBy('name')->pluck('name', 'id')->toArray(),
             'experiences'         => Experience::orderBy('name')->pluck('name', 'id')->toArray(),
+            'skills'           => Skill::pluck('name', 'id')->toArray(),
         ] : []));
     }
 
@@ -158,7 +158,6 @@ class SubmissionController extends Controller {
             'itemsrow'         => Item::all()->keyBy('id'),
             'expanded_rewards' => config('lorekeeper.extensions.character_reward_expansion.expanded'),
             'characters'       => Character::visible(Auth::user() ?? null)->myo(0)->orderBy('slug', 'DESC')->get()->pluck('fullName', 'slug')->toArray(),
-            'skills'           => Skill::pluck('name', 'id')->toArray(),
         ] + ($submission->status == 'Pending' ? [
             'characterCurrencies' => Currency::where('is_character_owned', 1)->orderBy('sort_character', 'DESC')->pluck('name', 'id'),
             'items'               => Item::orderBy('name')->pluck('name', 'id'),
@@ -171,6 +170,7 @@ class SubmissionController extends Controller {
             'classes'             => CharacterClass::orderBy('name')->pluck('name', 'id'),
             'points'              => Stat::orderBy('name')->pluck('name', 'id')->toArray(),
             'experiences'         => Experience::orderBy('name')->pluck('name', 'id')->toArray(),
+            'skills'           => Skill::pluck('name', 'id')->toArray(),
         ] : []));
     }
 

--- a/resources/views/admin/submissions/submission.blade.php
+++ b/resources/views/admin/submissions/submission.blade.php
@@ -395,33 +395,6 @@
                     $submissionForm.attr('action', '{{ url()->current() }}/cancel');
                     $submissionForm.submit();
                 });
-
-                $('.original.skill-select').selectize();
-
-                $('#add-skill').on('click', function(e) {
-                    e.preventDefault();
-                    addSkillRow();
-                });
-                $('.remove-skill').on('click', function(e) {
-                    e.preventDefault();
-                    removeSkillRow($(this));
-                });
-
-                function addSkillRow() {
-                    var $clone = $('.skill-row').clone();
-                    $('#skillList').append($clone);
-                    $clone.removeClass('hide skill-row');
-                    $clone.addClass('d-flex');
-                    $clone.find('.remove-skill').on('click', function(e) {
-                        e.preventDefault();
-                        removeSkillRow($(this));
-                    })
-                    $clone.find('.skill-select').selectize();
-                }
-
-                function removeSkillRow($trigger) {
-                    $trigger.parent().remove();
-                }
             });
         </script>
     @endif

--- a/resources/views/character/_sidebar.blade.php
+++ b/resources/views/character/_sidebar.blade.php
@@ -8,9 +8,11 @@
         <div class="sidebar-item"><a href="{{ $character->url . '/pets' }}" class="{{ set_active('character/' . $character->slug . '/pets') }}">Pets</a></div>
         <div class="sidebar-item"><a href="{{ $character->url . '/inventory' }}" class="{{ set_active('character/' . $character->slug . '/inventory') }}">Inventory</a></div>
         <div class="sidebar-item"><a href="{{ $character->url . '/bank' }}" class="{{ set_active('character/' . $character->slug . '/bank') }}">Bank</a></div>
+        {{-- not implemented
         @if (config('lorekeeper.claymores_and_companions.visibility_settings.gear') || config('lorekeeper.claymores_and_companions.visibility_settings.weapons'))
             <div class="sidebar-item"><a href="{{ $character->url . '/equipment' }}" class="{{ set_active('character/' . $character->slug . '/equipment') }}">Equipment</a></div>
         @endif
+        --}}
         @if (config('lorekeeper.claymores_and_companions.visibility_settings.character_levels') || config('lorekeeper.claymores_and_companions.visibility_settings.character_stats'))
             <div class="sidebar-item"><a href="{{ $character->url . '/stats' }}" class="{{ set_active('character/' . $character->slug . '/stats') }}">Stats</a></div>
         @endif

--- a/resources/views/character/stats/count_logs.blade.php
+++ b/resources/views/character/stats/count_logs.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('profile-content')
-    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Level' => $character->url . '/level', 'Logs' => $character->url . '/stats/logs/count']) !!}
+    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Stat Logs' => $character->url . '/stats/logs', 'Count Logs' => $character->url . '/stats/logs/count']) !!}
 
     <h1>
         {!! $character->displayName !!}'s Count Logs

--- a/resources/views/character/stats/exp_logs.blade.php
+++ b/resources/views/character/stats/exp_logs.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('profile-content')
-    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Experience Logs' => $character->url . '/stats/logs/experience']) !!}
+    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Stat Logs' => $character->url . '/stats/logs', 'Experience Logs' => $character->url . '/stats/logs/experience']) !!}
 
     <h1>
         {!! $character->displayName !!}'s Experience Logs

--- a/resources/views/character/stats/exp_logs.blade.php
+++ b/resources/views/character/stats/exp_logs.blade.php
@@ -5,7 +5,13 @@
 @endsection
 
 @section('profile-content')
-    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Stat Logs' => $character->url . '/stats/logs', 'Experience Logs' => $character->url . '/stats/logs/experience']) !!}
+    {!! breadcrumbs([
+        'Characters' => 'characters',
+        $character->slug => $character->url,
+        'Stat Information' => $character->url . '/stats',
+        'Stat Logs' => $character->url . '/stats/logs',
+        'Experience Logs' => $character->url . '/stats/logs/experience',
+    ]) !!}
 
     <h1>
         {!! $character->displayName !!}'s Experience Logs

--- a/resources/views/character/stats/level_logs.blade.php
+++ b/resources/views/character/stats/level_logs.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('profile-content')
-    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Level' => $character->url . '/level', 'Logs' => $character->url . '/stats/logs/level']) !!}
+    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Stat Logs' => $character->url . '/stats/logs', 'Level Logs' => $character->url . '/stats/logs/level']) !!}
 
     <h1>
         {!! $character->displayName !!}'s Level Logs

--- a/resources/views/character/stats/stat_logs.blade.php
+++ b/resources/views/character/stats/stat_logs.blade.php
@@ -1,14 +1,14 @@
 @extends('character.layout', ['isMyo' => $character->is_myo_slot])
 
 @section('profile-title')
-    {{ $character->slug }}'s Stat Logs
+    {{ $character->slug }}'s Stat Activity Logs
 @endsection
 
 @section('profile-content')
-    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Stat Logs' => $character->url . '/stats/logs']) !!}
+    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Stat Logs' => $character->url . '/stats/logs', 'Stat Activity Logs' => $character->url . '/stats/logs/stat-points']) !!}
 
     <h1>
-        {!! $character->displayName !!}'s Stat Logs
+        {!! $character->displayName !!}'s Stat Activity Logs
     </h1>
 
     <h3>Transfers</h3>

--- a/resources/views/character/stats/stat_logs.blade.php
+++ b/resources/views/character/stats/stat_logs.blade.php
@@ -5,7 +5,13 @@
 @endsection
 
 @section('profile-content')
-    {!! breadcrumbs(['Characters' => 'characters', $character->slug => $character->url, 'Stat Information' => $character->url . '/stats', 'Stat Logs' => $character->url . '/stats/logs', 'Stat Activity Logs' => $character->url . '/stats/logs/stat-points']) !!}
+    {!! breadcrumbs([
+        'Characters' => 'characters',
+        $character->slug => $character->url,
+        'Stat Information' => $character->url . '/stats',
+        'Stat Logs' => $character->url . '/stats/logs',
+        'Stat Activity Logs' => $character->url . '/stats/logs/stat-points',
+    ]) !!}
 
     <h1>
         {!! $character->displayName !!}'s Stat Activity Logs

--- a/routes/lorekeeper/browse.php
+++ b/routes/lorekeeper/browse.php
@@ -90,7 +90,6 @@ Route::group(['prefix' => 'character', 'namespace' => 'Characters'], function ()
     Route::get('{slug}', 'CharacterController@getCharacter');
     Route::get('{slug}/profile', 'CharacterController@getCharacterProfile');
     Route::get('{slug}/bank', 'CharacterController@getCharacterBank');
-    Route::get('{slug}/level', 'CharacterController@getCharacterLevel');
     Route::get('{slug}/status-effects', 'CharacterController@getCharacterStatusEffects');
     Route::get('{slug}/inventory', 'CharacterController@getCharacterInventory');
     Route::get('{slug}/images', 'CharacterController@getCharacterImages');


### PR DESCRIPTION
Just cleaning up some random stuff lol

- Fixes hardcoded experience ID in ConvertExperiencePoints
- Fixing breadcrumbs and titles on character stat logs to remove broken links and improve navigation
- Removed or commented out broken links (like `$character->url . '/equipment'`)
- Remove unused routes
- Remove remnants of PromptSkills