### PR TITLE
fix: misc fixes

### DIFF
--- a/app/Models/Pet/Pet.php
+++ b/app/Models/Pet/Pet.php
@@ -294,10 +294,6 @@ class Pet extends Model {
         if ($userpet->has_image) {
             return $userpet->imageUrl;
         }
-        // check if there is an evolution and variant
-        elseif ($userpet->evolution_id && $this->parent_id) {
-            return $userpet->evolution->imageUrl($userpet->pet);
-        }
         // evolution > variant
         elseif ($userpet->evolution_id) {
             return $userpet->evolution->imageUrl;

--- a/app/Services/PetManager.php
+++ b/app/Services/PetManager.php
@@ -483,7 +483,7 @@ class PetManager extends Service {
                 if (!$tag) {
                     throw new \Exception('Item is not a splice.');
                 }
-                if ($default == true && $tag->data['variant_ids']&& !in_array('default', $tag->data['variant_ids'])) {
+                if ($default == true && $tag->data['variant_ids'] && !in_array('default', $tag->data['variant_ids'])) {
                     throw new \Exception('Item can not change pet into the default variant.');
                 }
                 if ($default == false && $tag->data['variant_ids'] && !in_array($id, $tag->data['variant_ids'])) {

--- a/app/Services/PetManager.php
+++ b/app/Services/PetManager.php
@@ -461,8 +461,11 @@ class PetManager extends Service {
         try {
             // find parent if id is default
             if ($id == 0) {
+                $default = true;
                 $pet_type = Pet::find($pet->pet_id);
                 $id = $pet_type->parent == null ? null : $pet_type->parent->id;
+            } else {
+                $default = false;
             }
 
             if ($id == null) {
@@ -480,7 +483,10 @@ class PetManager extends Service {
                 if (!$tag) {
                     throw new \Exception('Item is not a splice.');
                 }
-                if ($tag->data['variant_ids'] && !in_array($id, $tag->data['variant_ids'])) {
+                if ($default == true && $tag->data['variant_ids']&& !in_array('default', $tag->data['variant_ids'])) {
+                    throw new \Exception('Item can not change pet into the default variant.');
+                }
+                if ($default == false && $tag->data['variant_ids'] && !in_array($id, $tag->data['variant_ids'])) {
                     throw new \Exception('Item is not a splice for this variant.');
                 }
                 if ($id == $pet->pet_id) {

--- a/app/Services/PetService.php
+++ b/app/Services/PetService.php
@@ -285,6 +285,9 @@ class PetService extends Service {
             if (DB::table('shop_stock')->where('item_id', $pet->id)->where('stock_type', 'Pet')->exists()) {
                 throw new \Exception('A shop currently stocks this pet. Please remove the pet before deleting it.');
             }
+            if (DB::table('pets')->where('parent_id', $pet->id)->where('count', '>', 0)->where('deleted_at', '!=', null)->exists()) {
+                throw new \Exception('At least one pet currently has this as a parent. Please remove the pet(s) before deleting it.');
+            }
 
             // Delete character drops and drop data if they exist
             if ($pet->dropData) {

--- a/app/Services/PetService.php
+++ b/app/Services/PetService.php
@@ -285,7 +285,7 @@ class PetService extends Service {
             if (DB::table('shop_stock')->where('item_id', $pet->id)->where('stock_type', 'Pet')->exists()) {
                 throw new \Exception('A shop currently stocks this pet. Please remove the pet before deleting it.');
             }
-            if (DB::table('pets')->where('parent_id', $pet->id)->where('count', '>', 0)->where('deleted_at', '!=', null)->exists()) {
+            if (DB::table('pets')->where('parent_id', $pet->id)->exists()) {
                 throw new \Exception('At least one pet currently has this as a parent. Please remove the pet(s) before deleting it.');
             }
 


### PR DESCRIPTION
- remove old evolution image code that isn't needed anymore (or at least, not in this form.... there's an issue rn where if you switch a pet's variant while it's evolved it'll keep the old evolution ID. there needs to be some kind of evolution equivalency logic or like make it reset the evolution or something when switching variants. idk need to think on it more)
- switching to default variant with a splice item fixes
- throw an error if you try to delete a pet with extant children